### PR TITLE
Custom image prefixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "toltecmk"
-version = "0.3.0"
+version = "0.3.1"
 authors = [
   { name="Mattéo Delabre", email="git.matteo@delab.re" },
   { name="Eeems", email="eeems@eeems.email" },

--- a/toltec/__main__.py
+++ b/toltec/__main__.py
@@ -73,6 +73,17 @@ def main() -> int:  # pylint:disable=too-many-branches
         either a dot or a slash""",
     )
 
+    # add an argument for image_prefix, which defaults to "ghcr.io/toltec-dev/"
+
+    parser.add_argument(
+        "-I",
+        "--image-prefix",
+        metavar="IMAGEPREFIX",
+        default="ghcr.io/toltec-dev/",
+        help="""prefix to use for the container image name (default:
+        ghcr.io/toltec-dev/)""",
+    )
+
     util.argparse_add_verbose(parser)
     util.argparse_add_warning(parser)
     args = parser.parse_args()
@@ -80,7 +91,7 @@ def main() -> int:  # pylint:disable=too-many-branches
 
     recipe_bundle = parse_recipe(args.recipe_dir)
 
-    with Builder(args.work_dir, args.dist_dir) as builder:
+    with Builder(args.work_dir, args.dist_dir, args.image_prefix) as builder:
         if args.hook:
             for ident in args.hook:
                 if ident and ident[0] in (".", "/"):

--- a/toltec/hooks/strip.py
+++ b/toltec/hooks/strip.py
@@ -45,7 +45,7 @@ def run_in_container(
     """Run a script in a container and log output"""
     logs = bash.run_script_in_container(
         builder.docker,
-        image=builder.IMAGE_PREFIX + TOOLCHAIN,
+        image=builder.get_image_prefix() + TOOLCHAIN,
         mounts=[
             docker.types.Mount(
                 type="bind",


### PR DESCRIPTION
Hi thanks for Toltec and the great tooling around the reMarkable.

I'm not sure if this PR would be helpful, but I wanted to submit it in case it was. I've been building locally and finding a need to point to my own container registry while doing so.

This PR let's a user pass in an `--image-prefix` like so: `toltecmk --image-prefix "ghcr.io/chriscohoat/"`, which let's a user build from an alternate location. It defaults to `ghcr.io/toltec-dev/`, if not provided.

If this isn't desired no worries, happy to close it out. Thanks again!