### PR TITLE
Upgrade toolchain to v3

### DIFF
--- a/toltec/hooks/strip.py
+++ b/toltec/hooks/strip.py
@@ -20,7 +20,7 @@ from toltec.util import listener
 logger = logging.getLogger(__name__)
 
 MOUNT_SRC = "/src"
-TOOLCHAIN = "toolchain:v1.3.1"
+TOOLCHAIN = "toolchain:v3.1"
 
 
 def walk_elfs(src_dir: str, for_each: Callable) -> None:


### PR DESCRIPTION
Related to https://github.com/toltec-dev/toltec/issues/950, and this PR fixes usage of `patch_rm2fb`
```bash
$ docker run --rm -it -v `pwd`:/work ghcr.io/toltec-dev/toolchain:v1.3.1 bash
root@2ad815a1eebc:/# apt-get update
Ign:1 http://deb.debian.org/debian buster InRelease
Ign:2 http://deb.debian.org/debian buster-updates InRelease
Err:3 http://deb.debian.org/debian buster Release
  404  Not Found [IP: 151.101.62.132 80]
Err:4 http://deb.debian.org/debian buster-updates Release
  404  Not Found [IP: 151.101.62.132 80]
Ign:5 http://security.debian.org/debian-security buster/updates InRelease
Err:6 http://security.debian.org/debian-security buster/updates Release
  404  Not Found [IP: 151.101.62.132 80]
Reading package lists... Done
E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
E: The repository 'http://security.debian.org/debian-security buster/updates Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.