### PR TITLE
Don't indent end-of-file marker

### DIFF
--- a/toltec/hooks/install_lib.py
+++ b/toltec/hooks/install_lib.py
@@ -152,7 +152,7 @@ def register(builder: Builder) -> None:
 
     [Install]
     WantedBy=local-fs.target
-    UNIT
+UNIT
 
     systemctl daemon-reload
     systemctl enable "$unit_name"


### PR DESCRIPTION
Currently, the `add-bind-mount` code adds something like
```
    cat > "$unit_path" << UNIT
    [Unit]
    Description=Bind mount $1 over $2
    DefaultDependencies=no
    Conflicts=umount.target
    Before=local-fs.target umount.target

    [Mount]
    What=$1
    Where=$2
    Type=none
    Options=bind

    [Install]
    WantedBy=local-fs.target
    UNIT

    systemctl daemon-reload
```
with `UNIT` indented, which gets you errors like 
```
Configuring templatectl.
//opt/lib/opkg/info/templatectl.postinst: line 998: warning: here-document at line 21 delimited by end-of-file (wanted `UNIT')
//opt/lib/opkg/info/templatectl.postinst: line 999: syntax error: unexpected end of file
```

This PR unindents that.